### PR TITLE
Fix popular movies parsing and production logo rendering

### DIFF
--- a/scripts/movie-page.js
+++ b/scripts/movie-page.js
@@ -114,15 +114,17 @@ export const generateDetailsCard = (movieDetails) => {
           <div class="details-container">
             <span class="details-title">Production Companies</span>
             <div class="production-companies">
-              ${movieDetails.production_companies.map((v) => {
-                if (!v.logo_path) return null;
-                return `
+              ${movieDetails.production_companies
+                .filter((v) => v.logo_path)
+                .map(
+                  (v) => `
                     <img
                         class="production-image"
                         src="https://image.tmdb.org/t/p/w500${v.logo_path}"
                     />
-                `;
-              })}
+                `
+                )
+                .join("")}
             </div>
           </div>
         </div>

--- a/scripts/movies.js
+++ b/scripts/movies.js
@@ -2,16 +2,23 @@
 
 export const FAVORITES_KEY = "user_favorites";
 
+/**
+ * Fetches a list of popular movies from TMDb.
+ *
+ * @returns {Promise<import("./typedefs/movies").SearchResponse>}
+ */
 export const getPopularMovies = async () => {
   const url = "https://api.themoviedb.org/3/movie/popular";
   const headers = {
     Authorization: "replace-api-token",
   };
 
-  return await fetch(url, {
-    method: "GET",
-    headers,
-  });
+  return await (
+    await fetch(url, {
+      method: "GET",
+      headers,
+    })
+  ).json();
 };
 
 /**


### PR DESCRIPTION
## Summary
- parse popular movies API response to return JSON data
- render production company logos without comma separators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af716df3c8323b203233f788705f9